### PR TITLE
New library entrypoint to hide private names

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,0 +1,1 @@
+#import "oxifmt.typ": strfmt

--- a/tests/strfmt-tests.typ
+++ b/tests/strfmt-tests.typ
@@ -1,4 +1,5 @@
-#import "../oxifmt.typ": strfmt, using-0120
+#import "../lib.typ": strfmt
+#import "../oxifmt.typ": using-0120
 
 #{
   // test basics (sequential args, named args, pos args)

--- a/typst.toml
+++ b/typst.toml
@@ -4,5 +4,5 @@ version = "0.3.0"
 authors = ["PgBiel <https://github.com/PgBiel>"]
 license = "MIT OR Apache-2.0"
 description = "Convenient Rust-like string formatting in Typst"
-entrypoint = "oxifmt.typ"
+entrypoint = "lib.typ"
 repository = "https://github.com/PgBiel/typst-oxifmt"


### PR DESCRIPTION
Ensure private oxifmt names can't be imported, only `strfmt`.